### PR TITLE
Added missing method copyLibraryItem()

### DIFF
--- a/JSFLSupport 3.0/src/org/jsflsupport/libraries/JSFLTopLevel.js
+++ b/JSFLSupport 3.0/src/org/jsflsupport/libraries/JSFLTopLevel.js
@@ -288,15 +288,15 @@ Flash.prototype.closeDocument = function (documentObject, bPromptToSaveChanges) 
 };
 /**
  * @since Flash CS5
- * @param {"fileURI"} [string]
- * @param {"libraryItemPath"} [string]
+ * @param {string} fileURI
+ * @param {string} libraryItemPath
  * @return {boolean}
  */
 Flash.prototype.copyLibraryItem = function (fileURI, libraryItemPath) {
 };
 /**
  * @since Flash MX 2004
- * @param {string} [docType]
+ * @param {"timeline"|"htmlcanvas"|"vrPanoDoc"|"vr360Doc"} [docType="timeline"]
  * @return {Document}
  */
 Flash.prototype.createDocument = function (docType) {

--- a/JSFLSupport 3.0/src/org/jsflsupport/libraries/JSFLTopLevel.js
+++ b/JSFLSupport 3.0/src/org/jsflsupport/libraries/JSFLTopLevel.js
@@ -287,8 +287,16 @@ Flash.prototype.closeAllPlayerDocuments = function () {
 Flash.prototype.closeDocument = function (documentObject, bPromptToSaveChanges) {
 };
 /**
+ * @since Flash CS5
+ * @param {"fileURI"} [string]
+ * @param {"libraryItemPath"} [string]
+ * @return {boolean}
+ */
+Flash.prototype.copyLibraryItem = function (fileURI, libraryItemPath) {
+};
+/**
  * @since Flash MX 2004
- * @param {"timeline"} [docType]
+ * @param {string} [docType]
  * @return {Document}
  */
 Flash.prototype.createDocument = function (docType) {


### PR DESCRIPTION
I added a method that I've always noticed was missing. Additionally, the data type for the optional docType parameter on createDocument() was incorrect. You do great work! Here's the API referennce for the missing method. https://www.adobe.io/apis/creativecloud/animate/docs.html#!AdobeDocs/developers-animatesdk-docs/master/flash_object_(fl)/fl15.md