### PR TITLE
Update API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 JSFL Support
 ============
 
-<a target='_blank' href='https://plugins.jetbrains.com/plugin/7096-jsfl-support'>IntelliJ platform plugin</a> providing support for <a target='_blank' href='https://adobeio-prod.adobemsbasic.com/apis/creativecloud/animate/docs.html'>Adobe Animate JavaScript API</a>.
+<a target='_blank' href='https://plugins.jetbrains.com/plugin/7096-jsfl-support'>IntelliJ platform plugin</a> providing support for <a target='_blank' href='https://github.com/AdobeDocs/developers-animatesdk-docs/blob/master/index.md'>Animate JSAPI Documentation</a>.


### PR DESCRIPTION
Hey, bud! Looks like Adobe went and changed the API location again. Now it seems to be in the AdobeDocs GitHub repo. I'm pretty happy they moved it. But the old links appear to be dead.